### PR TITLE
Linux syntax fix

### DIFF
--- a/sudoku.py
+++ b/sudoku.py
@@ -1,4 +1,4 @@
-import SudokuPuzzles
+import sudokuPuzzles
 import SudokuSolver
 import Argparser
 
@@ -6,7 +6,7 @@ argparser = Argparser.Argparser()
 find_all = argparser.find_all
 puzzle_number = argparser.puzzle_number
 
-puzzles = SudokuPuzzles.puzzle_dict
+puzzles = sudokuPuzzles.puzzle_dict
 
 
 def show_solutions(solutions):


### PR DESCRIPTION
I was initially unable to run the program on Linux due to a lower/capital case difference when loading the module `sudokuPuzzles.py`. This is likely due to that Windows does not recognize cases, while Linux do. This pull request fixes the problem on my Linux machine.